### PR TITLE
Get rid of usage of ext/session in favor of storing authentication data in cookies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "monolog/monolog": "^1.19",
         "symfony/monolog-bridge": "^3.1",
         "symfony/event-dispatcher": "^3.1",
-        "symfony/http-foundation": "^3.1",
+        "psr7-sessions/storageless": "^2.0",
         "league/commonmark": "^0.14.0",
         "gravatarphp/gravatar": "^1.0",
         "gravatarphp/twig-integration": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ec14e56d9129738f60473ed0ff077733",
-    "content-hash": "5424121aa15a2dbe27c84d0cc23c890a",
+    "hash": "a6e47771f3fb7a47a2021c9b10d2c4a1",
+    "content-hash": "9ff5a8b01455bc70ec32e238d022b9c3",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -132,6 +132,58 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "time": "2014-12-30 15:22:37"
+        },
+        {
+            "name": "dflydev/fig-cookies",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-fig-cookies.git",
+                "reference": "883233c159d00d39e940bd12cfe42c0d23420c1c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/883233c159d00d39e940bd12cfe42c0d23420c1c",
+                "reference": "883233c159d00d39e940bd12cfe42c0d23420c1c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/http-message": "~1.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "~0.1@dev",
+                "phpunit/phpunit": "~4.5",
+                "squizlabs/php_codesniffer": "~2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dflydev\\FigCookies\\": "src/Dflydev/FigCookies"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com"
+                }
+            ],
+            "description": "Cookies for PSR-7 HTTP Message Interface.",
+            "keywords": [
+                "cookies",
+                "psr-7",
+                "psr7"
+            ],
+            "time": "2016-03-28 09:10:18"
         },
         {
             "name": "doctrine/annotations",
@@ -985,6 +1037,58 @@
             "time": "2016-06-24 23:00:38"
         },
         {
+            "name": "http-interop/http-middleware",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-middleware.git",
+                "reference": "ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9",
+                "reference": "ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Http\\Middleware\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP middleware",
+            "keywords": [
+                "factory",
+                "http",
+                "middleware",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-09-25 13:30:27"
+        },
+        {
             "name": "ircmaxell/random-lib",
             "version": "v1.1.0",
             "source": {
@@ -1144,6 +1248,64 @@
                 "schema"
             ],
             "time": "2016-01-25 15:43:01"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "ddce703826f9c5229781933b1a39069e38e6a0f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/ddce703826f9c5229781933b1a39069e38e6a0f3",
+                "reference": "ddce703826f9c5229781933b1a39069e38e6a0f3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "mdanter/ecc": "~0.3.1",
+                "mikey179/vfsstream": "~1.5",
+                "phpmd/phpmd": "~2.2",
+                "phpunit/php-invoker": "~1.1",
+                "phpunit/phpunit": "~4.5",
+                "squizlabs/php_codesniffer": "~2.3"
+            },
+            "suggest": {
+                "mdanter/ecc": "Required to use Elliptic Curves based algorithms."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Otávio Cobucci Oblonczyk",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "time": "2016-10-31 20:09:32"
         },
         {
             "name": "league/commonmark",
@@ -2453,6 +2615,65 @@
             "time": "2012-12-21 11:40:51"
         },
         {
+            "name": "psr7-sessions/storageless",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psr7-sessions/storageless.git",
+                "reference": "94bcd47b4f90c05b56839c138c134f3975aa0046"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psr7-sessions/storageless/zipball/94bcd47b4f90c05b56839c138c134f3975aa0046",
+                "reference": "94bcd47b4f90c05b56839c138c134f3975aa0046",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/fig-cookies": "^1.0",
+                "lcobucci/jwt": "^3.1",
+                "php": "~7.0",
+                "psr/http-message": "^1.0",
+                "zendframework/zend-stratigility": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0",
+                "zendframework/zend-diactoros": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PSR7Session\\": "src/PSR7Session"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Otávio Cobucci Oblonczyk",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Jefersson Nathan",
+                    "email": "malukenho@phpse.net"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/",
+                    "role": "Developer"
+                }
+            ],
+            "time": "2016-05-29 13:39:13"
+        },
+        {
             "name": "puli/composer-plugin",
             "version": "1.0.0-beta10",
             "source": {
@@ -3273,16 +3494,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.1.3",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "399a44b73f6c176de40fb063dcdaa578bcfb94d6"
+                "reference": "9963bc29d7f4398b137dd8efc480efe54fdbe5f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/399a44b73f6c176de40fb063dcdaa578bcfb94d6",
-                "reference": "399a44b73f6c176de40fb063dcdaa578bcfb94d6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9963bc29d7f4398b137dd8efc480efe54fdbe5f1",
+                "reference": "9963bc29d7f4398b137dd8efc480efe54fdbe5f1",
                 "shasum": ""
             },
             "require": {
@@ -3295,7 +3516,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -3322,7 +3543,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-17 14:02:08"
+            "time": "2016-11-27 04:21:38"
         },
         {
             "name": "symfony/http-kernel",
@@ -4010,6 +4231,103 @@
                 "psr-7"
             ],
             "time": "2016-03-17 18:02:05"
+        },
+        {
+            "name": "zendframework/zend-escaper",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-escaper.git",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-escaper",
+            "keywords": [
+                "escaper",
+                "zf2"
+            ],
+            "time": "2016-06-30 19:48:38"
+        },
+        {
+            "name": "zendframework/zend-stratigility",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stratigility.git",
+                "reference": "ffbf29ceb92a9223b8383ea2b021b242591141d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/ffbf29ceb92a9223b8383ea2b021b242591141d2",
+                "reference": "ffbf29ceb92a9223b8383ea2b021b242591141d2",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-middleware": "^0.2.0",
+                "php": "^5.6 || ^7.0",
+                "psr/http-message": "^1.0",
+                "zendframework/zend-escaper": "^2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.6",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-diactoros": "^1.0"
+            },
+            "suggest": {
+                "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., zendframework/zend-diactoros"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.0-dev",
+                    "dev-develop": "2.0.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stratigility\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Middleware for PHP",
+            "homepage": "https://github.com/zendframework/zend-stratigility",
+            "keywords": [
+                "http",
+                "middleware",
+                "psr-7"
+            ],
+            "time": "2017-01-05 22:22:10"
         }
     ],
     "packages-dev": [

--- a/puli.json
+++ b/puli.json
@@ -20,6 +20,10 @@
             "install-path": "vendor/container-interop/container-interop",
             "installer": "composer"
         },
+        "dflydev/fig-cookies": {
+            "install-path": "vendor/dflydev/fig-cookies",
+            "installer": "composer"
+        },
         "doctrine/annotations": {
             "install-path": "vendor/doctrine/annotations",
             "installer": "composer"
@@ -81,6 +85,10 @@
             "install-path": "vendor/guzzlehttp/psr7",
             "installer": "composer"
         },
+        "http-interop/http-middleware": {
+            "install-path": "vendor/http-interop/http-middleware",
+            "installer": "composer"
+        },
         "ircmaxell/random-lib": {
             "install-path": "vendor/ircmaxell/random-lib",
             "installer": "composer"
@@ -91,6 +99,10 @@
         },
         "justinrainbow/json-schema": {
             "install-path": "vendor/justinrainbow/json-schema",
+            "installer": "composer"
+        },
+        "lcobucci/jwt": {
+            "install-path": "vendor/lcobucci/jwt",
             "installer": "composer"
         },
         "league/commonmark": {
@@ -277,6 +289,10 @@
             "install-path": "vendor/psr/log",
             "installer": "composer"
         },
+        "psr7-sessions/storageless": {
+            "install-path": "vendor/psr7-sessions/storageless",
+            "installer": "composer"
+        },
         "puli/composer-plugin": {
             "install-path": "vendor/puli/composer-plugin",
             "installer": "composer"
@@ -450,6 +466,14 @@
         },
         "zendframework/zend-diactoros": {
             "install-path": "vendor/zendframework/zend-diactoros",
+            "installer": "composer"
+        },
+        "zendframework/zend-escaper": {
+            "install-path": "vendor/zendframework/zend-escaper",
+            "installer": "composer"
+        },
+        "zendframework/zend-stratigility": {
+            "install-path": "vendor/zendframework/zend-stratigility",
             "installer": "composer"
         }
     }

--- a/res/config/config.php
+++ b/res/config/config.php
@@ -19,6 +19,7 @@ use League\OAuth2\Client\Provider\Github;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use PSR7Session\Http\SessionMiddleware;
 use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
 use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
 
@@ -92,4 +93,8 @@ return [
     \AlgoliaSearch\Client::class => object()
         ->constructor(get('algolia.app_id'), get('algolia.api_key')),
 
+    SessionMiddleware::class => function (ContainerInterface $c) {
+        $config = $c->get('session');
+        return SessionMiddleware::fromSymmetricKeyDefaults($config['key'], $config['lifetime']);
+    },
 ];

--- a/res/config/parameters.php.dist
+++ b/res/config/parameters.php.dist
@@ -18,4 +18,8 @@ return [
     'algolia.app_id' => '',
     'algolia.api_key' => '',
 
+    'session' => [
+        'key' => '',
+        'lifetime' => 31536000,
+    ],
 ];

--- a/src/Application/Controller/AuthController.php
+++ b/src/Application/Controller/AuthController.php
@@ -9,7 +9,7 @@ use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Provider\GithubResourceOwner;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use PSR7Session\Http\SessionMiddleware;
 use Twig_Environment;
 use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Diactoros\Response\RedirectResponse;
@@ -45,7 +45,7 @@ class AuthController
     {
         newrelic_name_transaction('login');
 
-        $session = $request->getAttribute(SessionInterface::class);
+        $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
         // If already logged in
         $user = $session->get('user');
@@ -94,7 +94,7 @@ class AuthController
     public function logout(ServerRequestInterface $request)
     {
         newrelic_name_transaction('logout');
-        $session = $request->getAttribute(SessionInterface::class);
+        $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
         $session->remove('user');
         return new RedirectResponse('/');
     }

--- a/src/Application/Middleware/AuthMiddleware.php
+++ b/src/Application/Middleware/AuthMiddleware.php
@@ -3,10 +3,11 @@ declare(strict_types = 1);
 
 namespace Externals\Application\Middleware;
 
+use Externals\User\User;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use PSR7Session\Http\SessionMiddleware;
 use Stratify\Http\Middleware\Middleware;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Set the user in the request.
@@ -17,9 +18,9 @@ class AuthMiddleware implements Middleware
 {
     public function __invoke(ServerRequestInterface $request, callable $next) : ResponseInterface
     {
-        $session = $request->getAttribute(SessionInterface::class);
+        $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
-        $request = $request->withAttribute('user', $session->get('user'));
+        $request = $request->withAttribute('user', User::fromData($session->get('user')));
 
         return $next($request);
     }

--- a/src/Application/Middleware/SessionMiddleware.php
+++ b/src/Application/Middleware/SessionMiddleware.php
@@ -6,8 +6,8 @@ namespace Externals\Application\Middleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Stratify\Http\Middleware\Middleware;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use PSR7Session\Http\SessionMiddleware as Psr7Middleware;
+use Zend\Diactoros\Response\EmptyResponse;
 
 /**
  * Creates and set a session object in the request.
@@ -16,12 +16,18 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class SessionMiddleware implements Middleware
 {
+    /**
+     * @var Psr7Middleware
+     */
+    private $middleware;
+
+    public function __construct(Psr7Middleware $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
     public function __invoke(ServerRequestInterface $request, callable $next) : ResponseInterface
     {
-        $session = new Session;
-
-        $request = $request->withAttribute(SessionInterface::class, $session);
-
-        return $next($request);
+        return ($this->middleware)($request, new EmptyResponse(), $next);
     }
 }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -6,7 +6,7 @@ namespace Externals\User;
 /**
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class User implements \Serializable
+class User implements \JsonSerializable
 {
     /**
      * @var int
@@ -46,26 +46,24 @@ class User implements \Serializable
     }
 
     /**
-     * @link http://php.net/manual/en/serializable.serialize.php
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
      * @return string
      */
-    public function serialize()
+    public function jsonSerialize()
     {
-        return serialize([
+        return [
             'id' => $this->id,
             'githubId' => $this->githubId,
             'name' => $this->name,
-        ]);
+        ];
     }
 
-    public function unserialize($serialized)
+    public static function fromData($data)
     {
-        $data = unserialize($serialized);
-        if (!$data) {
-            throw new \Exception('Unable to unserialize user');
+        if ($data === null) {
+            return null;
         }
-        $this->id = $data['id'];
-        $this->githubId = $data['githubId'];
-        $this->name = $data['name'];
+
+        return new self($data['id'], $data['githubId'], $data['name']);
     }
 }

--- a/tests/Application/Middleware/SessionMiddlewareTest.php
+++ b/tests/Application/Middleware/SessionMiddlewareTest.php
@@ -5,7 +5,8 @@ namespace Externals\Test\Application\Middleware;
 
 use Externals\Application\Middleware\SessionMiddleware;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use PSR7Session\Http\SessionMiddleware as Psr7Middleware;
+use PSR7Session\Session\SessionInterface;
 use Zend\Diactoros\Response\TextResponse;
 use Zend\Diactoros\ServerRequest;
 
@@ -18,11 +19,13 @@ class SessionMiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $next = function (ServerRequestInterface $request) {
             // Check that the session is now in the request
-            $this->assertInstanceOf(SessionInterface::class, $request->getAttribute(SessionInterface::class));
+            $this->assertInstanceOf(SessionInterface::class, $request->getAttribute(Psr7Middleware::SESSION_ATTRIBUTE));
             return new TextResponse('Hello');
         };
 
-        $response = (new SessionMiddleware)->__invoke(new ServerRequest, $next);
+        $response = (new SessionMiddleware(
+            Psr7Middleware::fromSymmetricKeyDefaults('the-key', 3600)
+        ))->__invoke(new ServerRequest, $next);
 
         // Check that next was called
         $this->assertEquals('Hello', $response->getBody()->getContents());


### PR DESCRIPTION
Solves #19.

The key changes are:

1. The dependency on `symfony/http-foundation` is replaced with `psr7-sessions/storageless`.
2. Two new configuration parameters are introduced: session encryption key and lifetime (1 year by default).
3. The `User` class doesn't implement `Serializable` anymore but implements `JsonSerializable` instead as [required](https://github.com/psr7-sessions/storageless/blob/2.0.0/src/PSR7Session/Session/DefaultSessionData.php#L154) by `psr7-sessions/storageless`.
4. Due to the [specifics](https://github.com/psr7-sessions/storageless/blob/2.0.0/src/PSR7Session/Http/SessionMiddleware.php#L132) of `psr7-sessions/storageless`, GitHub authentication currently doesn't work in case if the application is accessed over HTTP.