### PR TITLE
responsive "next unread msg" control

### DIFF
--- a/res/views/thread.html.twig
+++ b/res/views/thread.html.twig
@@ -47,10 +47,10 @@
     </div>
 
     {% if user is not empty %}
-        <div class="thread-navigation visible-lg container">
-            <div class="navigation">
-                go to next <br> unread email
-                <button id="next-unread" type="button" class="btn btn-link btn-block"><span class="fa fa-arrow-down"></span></button>
+        <div class="thread-navigation container">
+            <div class="navigation" id="next-unread">
+                next<br>unread email
+                <button type="button" class="btn btn-link btn-block"><span class="fa fa-arrow-down"></span></button>
             </div>
         </div>
     {% endif %}

--- a/res/views/thread.html.twig
+++ b/res/views/thread.html.twig
@@ -48,9 +48,9 @@
 
     {% if user is not empty %}
         <div class="thread-navigation container">
-            <div class="navigation" id="next-unread">
+            <div class="navigation">
                 next<br>unread email
-                <button type="button" class="btn btn-link btn-block"><span class="fa fa-arrow-down"></span></button>
+                <button id="next-unread" type="button" class="btn btn-link btn-block"><span class="fa fa-arrow-down"></span></button>
             </div>
         </div>
     {% endif %}

--- a/web/css/style.less
+++ b/web/css/style.less
@@ -265,13 +265,23 @@ article article article, article article article article article, article articl
 .thread-navigation {
     .navigation {
         position: fixed;
-        right: 3%;
-        top: 176px;
+        right: 2%;
+        bottom: 2%;
         text-align: center;
         color: #428bca;
-        font-size: 12px;
+        
+        font-size: 10px;
         button {
-            font-size: 50px;
+            font-size: 25px;
+        }
+        
+        @media (min-width: 768px) {
+            font-size: 12px;
+            button {
+                top: 176px;
+                bottom: auto;
+                font-size: 50px;
+            }
         }
     }
 }

--- a/web/css/style.less
+++ b/web/css/style.less
@@ -275,7 +275,7 @@ article article article, article article article article article, article articl
             font-size: 25px;
         }
         
-        @media (min-width: 768px) {
+        @media (min-width: 1050px) {
             font-size: 12px;
             button {
                 top: 176px;


### PR DESCRIPTION
updated the css so the "next unread message" control is visible even on mobile/tablets.

the control is rendered in a smaller version on the bottom right.
look and feel on devices with > 1050px like before.

### before:

![grafik](https://cloud.githubusercontent.com/assets/120441/22404370/e1221aca-e62f-11e6-981c-ad356d20880a.png)

![grafik](https://cloud.githubusercontent.com/assets/120441/22404371/e6d48fca-e62f-11e6-8ac8-69b8edce7c59.png)

![grafik](https://cloud.githubusercontent.com/assets/120441/22404373/eae83da0-e62f-11e6-9fc4-867db3a14249.png)

### after this patch:
![grafik](https://cloud.githubusercontent.com/assets/120441/22404377/f62192d4-e62f-11e6-99f4-d1660e9f4fba.png)

![grafik](https://cloud.githubusercontent.com/assets/120441/22404379/faac25e4-e62f-11e6-9433-1d1e35cec10e.png)

![grafik](https://cloud.githubusercontent.com/assets/120441/22404380/ffc14ab4-e62f-11e6-9ac4-01f0e7fc48f0.png)


