### PR TITLE
hide navigation when no more unread messages left

### DIFF
--- a/res/views/thread.html.twig
+++ b/res/views/thread.html.twig
@@ -74,11 +74,15 @@
             var i = 0;
             $('#next-unread').click(function() {
                 if ((i + 1) > unreadEmailIds.length) {                              
-                    $('.thread-navigation').remove();
                     return;
                 }
                 window.location.hash = '#' + unreadEmailIds[i];
                 i++;
+
+                // hide navigation when no more unread messages left
+                if ((i + 1) > unreadEmailIds.length) {                              
+                    $('.thread-navigation').remove();
+                }
             });
             if (unreadEmailIds.length === 0) {
                 $('.thread-navigation').remove();


### PR DESCRIPTION
before the button stayed visible even no unread messages left.

a click on the button then made it hidden but no navigation was done because no more unread message to jump to.