### PR TITLE
Create an rss feed for the latest emails

### DIFF
--- a/res/http.php
+++ b/res/http.php
@@ -10,6 +10,7 @@ use Externals\Application\Middleware\NotFoundMiddleware;
 use Externals\Application\Middleware\SessionMiddleware;
 use Externals\Email\EmailRepository;
 use Externals\NotFound;
+use Externals\RssBuilder;
 use Externals\User\User;
 use Externals\User\UserRepository;
 use Externals\Voting;
@@ -97,6 +98,15 @@ return pipe([
                 'threads' => $repository->findTopThreads(1, $user),
                 'user' => $user,
             ]);
+        },
+
+        '/rss' => function (EmailRepository $emailRepository, ServerRequestInterface $request) {
+            newrelic_name_transaction('rss');
+            $query = $request->getQueryParams();
+            $since = (int) ($query['since'] ?? 0);
+            $rss = new RssBuilder($request);
+            $emails = $emailRepository->getRecent($since);
+            return $rss->build($emails);
         },
 
         '/news' => function (Twig_Environment $twig, ServerRequestInterface $request) {

--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="alternate" type="application/rss+xml" href="/rss" />
 
     <title>{% block pageTitle %}#externals - Opening PHP's #internals to the outside{% endblock %}</title>
 

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -162,8 +162,8 @@ class Email
         return $this->getThreadId() === $this->getId();
     }
 
-    public function getUrl()
+    public function getUrl() : string
     {
-        return '/thread/' . $this->getThreadId() . '#email-' . $this->getId();
+        return '/' . $this->getId();
     }
 }

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -161,4 +161,9 @@ class Email
     {
         return $this->getThreadId() === $this->getId();
     }
+
+    public function getUrl()
+    {
+        return '/thread/' . $this->getThreadId() . '#email-' . $this->getId();
+    }
 }

--- a/src/Email/EmailRepository.php
+++ b/src/Email/EmailRepository.php
@@ -161,6 +161,22 @@ SQL;
         return $numberOfEmails;
     }
 
+    /**
+     * @return Email[]
+     */
+    public function getRecent(int $since) : array
+    {
+        $qb = $this->db->createQueryBuilder();
+        $qb->select('*')
+            ->from('emails')
+            ->where('id > :since')
+            ->orderBy('id', 'ASC')
+            ->setMaxResults(100)
+            ->setParameter('since', $since);
+
+        return array_map([$this, 'createEmail'], $qb->execute()->fetchAll());
+    }
+
     public function add(Email $email)
     {
         $this->db->insert('emails', [

--- a/src/RssBuilder.php
+++ b/src/RssBuilder.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types = 1);
+
+namespace Externals;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @author Craig Duncan <git@duncanc.co.uk>
+ */
+class RssBuilder
+{
+    /**
+     * @var string $host The base url to use for links.
+     */
+    private $host;
+
+    /**
+     * @var \DomDocument|null $dom The current xml document being built.
+     */
+    private $dom;
+
+    public function __construct(ServerRequestInterface $request)
+    {
+        $this->host = (string) $request->getUri()->withPath("");
+    }
+
+
+    /**
+     * @param Email[] $emails
+     */
+    public function build(array $emails): string
+    {
+        $this->dom = new \DomDocument('1.0', 'utf-8');
+
+        $rss = $this->dom->createElement('rss');
+        $rss->setAttribute('xmlns:content', 'http://purl.org/rss/1.0/modules/content/');
+        $rss->setAttribute('xmlns:atom', 'http://www.w3.org/2005/Atom');
+        $rss->setAttribute('version', '2.0');
+        $this->dom->appendChild($rss);
+
+        $channel = $this->dom->createElement('channel');
+        $this->addTextNode('title', "#externals", $channel);
+        $this->addTextNode('link', $this->host, $channel);
+        $this->addTextNode('description', 'Opening PHP\'s #internals to the outside', $channel);
+        $this->addTextNode('pubDate', date('r'), $channel);
+        $this->addTextNode('lastBuildDate', date('r'), $channel);
+        $rss->appendChild($channel);
+
+        foreach ($emails as $email) {
+            $item = $this->dom->createElement('item');
+            $this->addTextNode('title', $email->getSubject(), $item);
+            $this->addTextNode('link', $this->host . $email->getUrl(), $item);
+            $this->addTextNode('description', $email->getContent(), $item);
+            $this->addTextNode('guid', $email->getId(), $item);
+            $this->addTextNode('pubDate', $email->getDate()->format('r'), $item);
+            $channel->appendChild($item);
+        }
+
+        return $this->dom->saveXML();
+    }
+
+
+    private function addTextNode($name, $value, \DomElement $parent)
+    {
+        $element = $this->dom->createElement($name);
+
+        $value = utf8_encode($value);
+        $node = $this->dom->createTextNode($value);
+        $element->appendChild($node);
+
+        $parent->appendChild($element);
+    }
+}


### PR DESCRIPTION
This pr provides an endpoint (https://externals.io/rss) for an RSS feed of emails.

I currently use [the php.net rss feed](http://news.php.net/group.php?group=php.internals&format=rss) to create notifications for any new internals posts. And then link to news.php.net to display them, however I'd rather link to `externals.io`.

I tried to follow the conventions of the project, but let me know if there's anything I've done wrong