### PR TITLE
show "next-unread" button after listeners are registered

### DIFF
--- a/res/assets/style.less
+++ b/res/assets/style.less
@@ -372,6 +372,10 @@ article article article, article article article article article, article articl
     }
 }
 
+#next-unread {
+    display: none;
+}
+
 .news {
     h2 {
         font-size: 28px;

--- a/res/views/thread.html.twig
+++ b/res/views/thread.html.twig
@@ -100,6 +100,8 @@
 
             if (unreadEmailIds.length === 0) {
                 $('.thread-navigation').remove();
+            } else {
+                $('#next-unread').show();
             }
         });
     </script>


### PR DESCRIPTION
as the listeners for the "next-unread" button are registered after jquery document ready, the button can be visible but does nothing when clicked.

this happend to me today, because some gravatars seem not to get loaded properly.

-> because of jquery document ready the listeners will only get registered after _all_ - even external resources - are completely loaded.

on the long run we should get this scripts into vanillajs land, so we dont need to wait for the jquery-lib to be loaded. until we get there use this kind of workaround to make things consistently work.