### PR TITLE
avoid error when git is not present

### DIFF
--- a/res/config/config.php
+++ b/res/config/config.php
@@ -36,7 +36,14 @@ return [
     'path.logs' => __DIR__ . '/../../var/log',
 
     'version' => env('PLATFORM_TREE_ID', factory(function () {
-        return trim(shell_exec('git rev-parse HEAD'));
+        $rev = shell_exec('git rev-parse HEAD');
+
+        if (null !== $rev) {
+            return trim($rev);
+        }
+
+        return null;
+
     })),
 
     'db.url' => env('DB_URL'),


### PR DESCRIPTION
If git is not available there were an error.
This adds a check to avoid the arror.