### PR TITLE
Load fonts later to speedup initial render

### DIFF
--- a/res/assets/style.less
+++ b/res/assets/style.less
@@ -19,7 +19,7 @@
 
 body {
     background-color: #FDFEFF;
-    font-family: 'Open Sans', sans-serif;
+    font-family: sans-serif;
 }
 h1 {
     font-weight: 300;

--- a/res/assets/style.less
+++ b/res/assets/style.less
@@ -21,6 +21,10 @@ body {
     background-color: #FDFEFF;
     font-family: sans-serif;
 }
+.fonts-loaded body {
+  font-family: 'Open Sans', sans-serif;
+}
+
 h1 {
     font-weight: 300;
 }

--- a/res/assets/style.less
+++ b/res/assets/style.less
@@ -22,7 +22,7 @@ body {
     font-family: sans-serif;
 }
 .fonts-loaded body {
-  font-family: 'Open Sans', sans-serif;
+    font-family: 'Open Sans', sans-serif;
 }
 
 h1 {

--- a/res/assets/style.less
+++ b/res/assets/style.less
@@ -21,7 +21,7 @@ body {
     background-color: #FDFEFF;
     font-family: sans-serif;
 }
-.fonts-loaded body {
+.wf-active body {
     font-family: 'Open Sans', sans-serif;
 }
 

--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -108,4 +108,15 @@
 
         });
     </script>
+    
+    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js"></script>
+    <script>
+    WebFont.load({
+       google: {
+         // 400 => normal
+         // 700 => bold
+         families: ['OpenSans:300,400,700']
+       }
+    });
+    </script>
 {% endblock %}

--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -115,7 +115,7 @@
        google: {
          // 400 => normal
          // 700 => bold
-         families: ['Open Sans:300,400,700']
+         families: ['Open Sans:300,400,400italic,700']
        }
     });
     </script>

--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -109,14 +109,16 @@
         });
     </script>
     
-    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js"></script>
     <script>
-    WebFont.load({
-       google: {
-         // 400 => normal
-         // 700 => bold
-         families: ['Open Sans:300,400,400italic,700']
+    function webfont_loaded() {
+       WebFont.load({
+          google: {
+            // 400 => normal
+            // 700 => bold
+            families: ['Open Sans:300,400,400italic,700']
+          }
        }
     });
     </script>
+    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js" onload="webfont_loaded" async></script>
 {% endblock %}

--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -115,7 +115,7 @@
        google: {
          // 400 => normal
          // 700 => bold
-         families: ['OpenSans:300,400,700']
+         families: ['Open Sans:300,400,700']
        }
     });
     </script>

--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -110,7 +110,7 @@
     </script>
     
     <script>
-    function webfont_loaded() {
+    function webfontlib_loaded() {
        WebFont.load({
           google: {
             // 400 => normal
@@ -120,5 +120,5 @@
        }
     });
     </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js" onload="webfont_loaded" async></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js" onload="webfontlib_loaded" async></script>
 {% endblock %}

--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -108,17 +108,5 @@
 
         });
     </script>
-    
-    <script>
-    function webfontlib_loaded() {
-       WebFont.load({
-          google: {
-            // 400 => normal
-            // 700 => bold
-            families: ['Open Sans:300,400,400italic,700']
-          }
-       }
-    });
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js" onload="webfontlib_loaded" async></script>
+
 {% endblock %}

--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -108,5 +108,5 @@
 
         });
     </script>
-
+    
 {% endblock %}

--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -108,5 +108,4 @@
 
         });
     </script>
-    
 {% endblock %}

--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -11,7 +11,6 @@
     <meta name="google-site-verification" content="hTdWskuVWUMoQAWfM3WcbBH16xhAxqzOyjfJbQmRor0" />
 
     <link rel="stylesheet" href="/dist/css/main.min.css?v={{ version }}">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,700" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.css">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">

--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -111,7 +111,7 @@
             });
         }
         </script>
-        <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js" onload="webfontlib_loaded" async></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" onload="webfontlib_loaded" async></script>
     {% endblock %}
 </body>
 </html>

--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -99,6 +99,19 @@
                 ga('send', 'pageview');
             </script>
         {% endif %}
+        
+        <script>
+        function webfontlib_loaded() {
+            WebFont.load({
+                google: {
+                // 400 => normal
+                // 700 => bold
+                    families: ['Open Sans:300,400,400italic,700']
+                }
+            });
+        }
+        </script>
+        <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js" onload="webfontlib_loaded" async></script>
     {% endblock %}
 </body>
 </html>

--- a/res/views/maintenance.html.twig
+++ b/res/views/maintenance.html.twig
@@ -7,7 +7,6 @@
     <title>{% block pageTitle %}#externals - Opening PHP's #internals to the outside{% endblock %}</title>
 
     <link rel="stylesheet" href="/dist/css/main.min.css?v={{ version }}">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,700" rel="stylesheet">
 </head>
 <body>
     <div class="container text-center">


### PR DESCRIPTION
Most of the time rendering the website is spent while loading fonts, see 
https://www.webpagetest.org/result/180907_6C_9abf7ebd4000568651e24bb3bfc7008a/1/details/#waterfall_view_step1 (without this change)

Disovered this perf issue because of unexpected slow load times while on vers slow mobile connections