### PR TITLE
Load search css later, so it wont block intial rendering

### DIFF
--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -14,6 +14,7 @@
         </noscript>
     </header>
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.css">
     {# Search #}
     <div id="search-form">
         <p class="algolia">

--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -11,7 +11,6 @@
     <meta name="google-site-verification" content="hTdWskuVWUMoQAWfM3WcbBH16xhAxqzOyjfJbQmRor0" />
 
     <link rel="stylesheet" href="/dist/css/main.min.css?v={{ version }}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.css">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="icon" type="image/png" href="/images/favicon-32x32.png" sizes="32x32" />


### PR DESCRIPTION
untested change, waiting for the PR patch deployment to verify.

Google chrome was the last browser which did not support this good practice.
With the recent release google chrome also supports loading of styles within the body without rendering impact

See https://jakearchibald.com/2016/link-in-body/