### PR TITLE
use vanillajs to build instantsearch markup templates

### DIFF
--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -95,8 +95,8 @@
                     container: '#search-results',
                     hitsPerPage: 10,
                     templates: {
-                        item: $('#search-result-template').html(),
-                        empty: $('#no-results-template').html(),
+                        item: document.querySelector('#search-result-template').innerHTML,
+                        empty: document.querySelector('#no-results-template').innerHTML,
                     }
                 })
             );


### PR DESCRIPTION
since the change in https://github.com/mnapoli/externals/pull/81 was deployed, there are some remaining js errors which should be fixed here.