### PR TITLE
load the font syncronously

### DIFF
--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -107,7 +107,7 @@
             });
         }
         </script>
-        <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" onload="webfontlib_loaded();" async></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" onload="webfontlib_loaded();"></script>
     {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
seems to be the easiert way to load for the "flash of unstyled text" in the short term

per docs in https://github.com/typekit/webfontloader#get-started