### PR TITLE
remove algoliasearch.js which is not required for instantsearch

### DIFF
--- a/res/views/home.html.twig
+++ b/res/views/home.html.twig
@@ -115,7 +115,6 @@
         });
     </script>
 
-    <script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
     <script src="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.js" onload="init_search();" async></script>
 
 {% endblock %}


### PR DESCRIPTION
in my local tests it showed up, that algoliasearch.js seems to be unnecessary for the instant-search input.

In case I did not miss another search feature within the app, this file is useless right now.