### PR TITLE
dont load a seperate font for italic

### DIFF
--- a/res/assets/style.less
+++ b/res/assets/style.less
@@ -283,7 +283,6 @@ article {
         .view-source, .view-source a {
             color: #cfcfcf;
             font-size: 0.9em;
-            font-style: italic;
         }
     }
     blockquote {

--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -10,7 +10,7 @@
 
     <meta name="google-site-verification" content="hTdWskuVWUMoQAWfM3WcbBH16xhAxqzOyjfJbQmRor0" />
     
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
 
     <link rel="stylesheet" href="/dist/css/main.min.css?v={{ version }}">
 


### PR DESCRIPTION
please see it as a suggestion.

If you have some special feelings for this single text to be styled italic, I am fine with it.
from a "overhead/performance" point of view loading a separate font just for this one text is overkill.

a single font-style costs us ~15kb + a few bytes required css.

if you are fine with the design change, merge it. feel free to close it otherwise.

before this change
![image](https://user-images.githubusercontent.com/120441/45565289-79334680-b853-11e8-8de7-23a8512ef29f.png)

after this change
![image](https://user-images.githubusercontent.com/120441/45565293-7c2e3700-b853-11e8-9070-9698aea75b10.png)
