### PR TITLE
Disable unread display in thread lists for guests

### DIFF
--- a/res/views/threads/thread-list.html.twig
+++ b/res/views/threads/thread-list.html.twig
@@ -1,5 +1,5 @@
 {% for thread in threads %}
-    <div class="thread-item {% if not thread.isRead and thread.userVote >= 0 %}unread{% endif %} {% if thread.votes < -1 %}unpopular{% endif %}">
+    <div class="thread-item {% if not thread.isRead and thread.userVote >= 0 and user is defined and user is not empty %}unread{% endif %} {% if thread.votes < -1 %}unpopular{% endif %}">
         <div class="vote-actions">
             <a class="vote-action upvote {{ (thread.userVote == 1) ? 'active' }}" href="#" data-email-id="{{ thread.number }}">
                 <i class="fa fa-chevron-up"> </i>


### PR DESCRIPTION
Hey,
This PR disables the bold fonts of unread threads if the visitor has not logged in, I think it looks better that way.
What do you think?