### PR TITLE
no longer load main.min.js async

### DIFF
--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -85,7 +85,7 @@
     </footer>
 
     {% block scripts %}
-        <script src="/dist/js/main.min.js?v={{ version }}" async></script>
+        <script src="/dist/js/main.min.js?v={{ version }}"></script>
 
         {% if not debug %}
             {# Google Analytics #}


### PR DESCRIPTION
I guess this should fix https://github.com/mnapoli/externals/issues/97