### PR TITLE
Indicate the 'n' shortcut in the link label

### DIFF
--- a/res/views/thread.html.twig
+++ b/res/views/thread.html.twig
@@ -51,7 +51,7 @@
     {% if user is not empty %}
         <div class="thread-navigation container">
             <div class="navigation" id="next-unread" title="press 'n' to jump to the next unread email">
-                next<br>unread email
+                (n)ext<br>unread email
                 <button type="button" class="btn btn-link btn-block"><span class="fa fa-arrow-down"></span></button>
             </div>
         </div>


### PR DESCRIPTION
We already describe the shortcut in the title tag, but this is not accessible on touch devices