### PR TITLE
Use preconnect headers to speedup rendering

### DIFF
--- a/res/views/layout.html.twig
+++ b/res/views/layout.html.twig
@@ -10,10 +10,10 @@
 
     <meta name="google-site-verification" content="hTdWskuVWUMoQAWfM3WcbBH16xhAxqzOyjfJbQmRor0" />
     
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
-    <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
-    <link rel="dns-prefetch" href="https://www.google-analytics.com">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="preconnect" href="https://www.google-analytics.com">
     
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
 


### PR DESCRIPTION
We use dns-prefetch before because of bad browser support of preconnect.

Preconnect is nowadays pretty good supported and leads to better results

Suggested in the lighthouse report: https://webpagetest.org/lighthouse.php?test=190206_34_e27d7ae95d2b3154c347edd29f556352&run=2

See https://caniuse.com/#feat=link-rel-preconnect

Closes https://github.com/mnapoli/externals/issues/63