### PR TITLE
Ensure text remains visible during webfont load

### DIFF
--- a/res/assets/style.less
+++ b/res/assets/style.less
@@ -19,6 +19,7 @@
 
 body {
     background-color: #FDFEFF;
+    font-display: fallback;
     font-family: 'Open Sans', sans-serif;
 }
 


### PR DESCRIPTION
Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading.

Suggested in the lighthouse report https://webpagetest.org/lighthouse.php?test=190206_34_e27d7ae95d2b3154c347edd29f556352&run=2

> fallback gives the font face an extremely small block period (100ms or less is recommended in most cases) and a short swap period (three seconds is recommended in most cases). In other words, the font face is rendered with a fallback at first if it’s not loaded, but the font is swapped as soon as it loads. However, if too much time passes, the fallback will be used for the rest of the page’s lifetime. fallback is a good candidate for things like body text where you’d like the user to start reading as soon as possible and don’t want to disturb their experience by shifting text around as a new font loads in.



See https://developers.google.com/web/updates/2016/02/font-display