### PR TITLE
Add github actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: build
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '7.4'
+                    tools: composer:v1
+
+            -   name: Git checkout
+                uses: actions/checkout@v2
+
+            -   name: Validate composer.json and composer.lock
+                run: composer validate
+
+            -   name: Prepare Composer cache vars
+                id: composer
+                run: |
+                    echo "::set-output name=cache_dir::$(composer config cache-files-dir)"
+                    echo "::set-output name=cache_key::$(date +'%Y-%m-%d')-composer-"
+
+            -   name: Cache Composer dependencies
+                uses: actions/cache@v2
+                with:
+                    path: ${{ steps.composer.outputs.cache_dir }}
+                    key: ${{ steps.composer.outputs.cache_key }}${{ hashFiles('**/composer.json') }}
+                    restore-keys: ${{ steps.composer.outputs.cache_key }}
+
+            -   name: Update Composer dependencies
+                run: composer update --prefer-dist --no-progress --no-suggest --no-interaction
+
+            -   name: Run PHPUnit
+                run: vendor/bin/phpunit --colors=always

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Externals.io
 
+[![Build status](https://github.com/mnapoli/externals/workflows/build/badge.svg?branch=master)](https://github.com/mnapoli/externals/actions)
+
 ## Setup
 
 Requirements (TODO: Vagrant box):
 
-- PHP 7.3 or above
+- PHP 7.4 or above
 - NPM
 - Gulp (install with `npm install gulp-cli -g`)
 - MySQL database


### PR DESCRIPTION
Regarding #141
This is simple github actions CI, running PHPUnit. Composer dependencies are cached by date. If there are no changes in dependencies - multiple builds at same day run faster.

See [build example](https://github.com/vstelmakh/externals/runs/1495611580?check_suite_focus=true) at repository fork.