### PR TITLE
Improve PHPUnit fixture

### DIFF
--- a/tests/Email/EmailContentParserTest.php
+++ b/tests/Email/EmailContentParserTest.php
@@ -11,7 +11,7 @@ class EmailContentParserTest extends TestCase
     /** @var EmailContentParser */
     private $parser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $modules = [
             'stratify/error-handler-module',


### PR DESCRIPTION
# Changed log

- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html?highlight=fixtures#fixtures), it should be the `protected function setUp(): void`.