### PR TITLE
Update styles to accomodate for deeply nested threads

### DIFF
--- a/views/thread.html.twig
+++ b/views/thread.html.twig
@@ -8,7 +8,7 @@
     {% set email = item.email %}
 
     <article id="{{ email.number }}"
-             class="mb-6 overflow-hidden {% if not email.isRead %}unread{% endif %}">
+             class="overflow-hidden {% if not email.isRead %}unread{% endif %}">
 
         <header class="text-xs sm:text-sm text-gray-300 bg-gray-600 rounded-tl py-1 px-2">
             <button data-target="#{{ email.number }}-body" type="button" class="thread-collapse-button mr-2">
@@ -30,11 +30,11 @@
             {% endif %}
         </header>
 
-        <div id="{{ email.number }}-body" class="border-l border-gray-200 pl-2 sm:px-4 pt-1 pb-1">
+        <div id="{{ email.number }}-body" class="border-l border-gray-200 pl-2 sm:pl-4 pt-1">
             <div class="email-content overflow-hidden text-sm sm:text-base mb-6">
                 {{ email.content|raw }}
             </div>
-            <div class="sm:ml-4 md:ml-6">
+            <div>
                 {% for reply in item.replies %}
                     {{ _self.threadItem(reply) }}
                 {% endfor %}


### PR DESCRIPTION
Addresses my comments made on https://github.com/mnapoli/externals/issues/159

- Removes bottom margin (doesn't add much value IMO)
- Removes right-side padding (`px` -> `pl`)
- Removes extra left-side padding on the nested thread items (the left padding on `<email.number>-body` element is sufficient IMO)

For example, see https://externals.io/message/113419#113602

After:

![image](https://user-images.githubusercontent.com/2111701/111656559-0539d680-87e1-11eb-8603-00fb437862e2.png)

![image](https://user-images.githubusercontent.com/2111701/111656622-171b7980-87e1-11eb-8675-e659b3d5d073.png)
