### PR TITLE
Move "next unread email" to bottom, show on mobile

### DIFF
--- a/views/thread.html.twig
+++ b/views/thread.html.twig
@@ -55,7 +55,7 @@
     </h1>
 
     {% if user is not empty %}
-        <button class="thread-navigation hidden lg:block fixed animate-pulse right-0 top-0 bg-white shadow-lg rounded-md px-4 py-2 mt-20 mr-5 bg-blue-50 text-blue-500 text-center text-sm transition-shadow hover:shadow-xl"
+        <button class="thread-navigation fixed animate-pulse right-0 bottom-0 bg-white shadow-lg rounded-md px-4 py-2 mr-5 mb-5 bg-blue-50 text-blue-500 text-center text-sm transition-shadow hover:shadow-xl"
              id="next-unread" type="button" title="press 'n' to jump to the next unread email">
             (n)ext unread email
         </button>


### PR DESCRIPTION
Fixes https://github.com/mnapoli/externals/issues/158

- Remove `hidden lg:block` to make it always appear on all display sizes
- Use `bottom-0` instead of `top-0` to move to the bottom
- Remove `mt-20`, no longer effectual since moving to the bottom
- Add `mb-5` to match the right-side margin

I think you may need to recompile tailwind classes, it seems like the set on prod didn't have `bottom-0`, but I figure that's already part of your pipeline. I'm just making these edits in github.