### PR TITLE
Make <pre> code blocks scrollable, more nesting colours

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -60,11 +60,28 @@ article blockquote blockquote {
 }
 
 /* Article nesting :p */
-article article, article article article article, article article article article article article {
+article article,
+article article article article,
+article article article article article article,
+article article article article article article article article, 
+article article article article article article article article article article,
+article article article article article article article article article article article article,
+article article article article article article article article article article article article article article {
     @apply bg-gray-50;
 }
-article article article, article article article article article, article article article article article article article {
+article article article,
+article article article article article,
+article article article article article article article, 
+article article article article article article article article article,
+article article article article article article article article article article article,
+article article article article article article article article article article article article article,
+article article article article article article article article article article article article article article article {
     @apply bg-white;
+}
+
+/* Horizontally scrollable code blocks */
+article pre {
+    @apply overflow-x-scroll;
 }
 
 @tailwind components;


### PR DESCRIPTION
Fixes another issue I mentioned in https://github.com/mnapoli/externals/issues/159#issuecomment-802025225 regarding `<pre>` not having scrollable overflow. This makes wide code blocks readable, before it would just run off to the side and get hidden.

Also added a bunch more nesting levels for the article gutters, because we have threads as deep as 15 levels now. Kinda goofy that it's done this way, but whatever I guess 😅