### PR TITLE
Fix next-unread z-index

### DIFF
--- a/views/thread.html.twig
+++ b/views/thread.html.twig
@@ -55,7 +55,7 @@
     </h1>
 
     {% if user is not empty %}
-        <button class="thread-navigation fixed animate-pulse right-0 bottom-0 bg-white shadow-lg rounded-md px-4 py-2 mr-5 mb-5 bg-blue-50 text-blue-500 text-center text-sm transition-shadow hover:shadow-xl"
+        <button class="thread-navigation fixed animate-pulse right-0 bottom-0 z-10 bg-white shadow-lg rounded-md px-4 py-2 mr-5 mb-5 bg-blue-50 text-blue-500 text-center text-sm transition-shadow hover:shadow-xl"
              id="next-unread" type="button" title="press 'n' to jump to the next unread email">
             (n)ext unread email
         </button>


### PR DESCRIPTION
Sets a z-index so that the button renders on top.

Problem:

![image](https://user-images.githubusercontent.com/2111701/111775406-1806e680-8887-11eb-8316-65659be8999f.png)

After:

![image](https://user-images.githubusercontent.com/2111701/111775483-3371f180-8887-11eb-9372-a6645d0af43b.png)
