### PR TITLE
Hide search container before search is initialized

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -87,5 +87,10 @@ article pre {
     @apply overflow-x-scroll;
 }
 
+/* Hide search box before initialization */
+#search-container {
+    display: none;
+}
+
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
The search container is displayed shortly when the page loads, and it will always be hidden afterwards anyway.