### PR TITLE
Update usernames if they changed

### DIFF
--- a/src/User/UserRepository.php
+++ b/src/User/UserRepository.php
@@ -11,22 +11,28 @@ class UserRepository
     ) {
     }
 
-    public function getOrCreate(string $githubId, string $name): User
+    public function getOrCreate(string $githubId, string $ghName): User
     {
         $userData = $this->db->fetchAssociative('SELECT * FROM users WHERE githubId = ?', [$githubId]);
 
         if ($userData) {
-            return new User((int) $userData['id'], $githubId, (string) $userData['name']);
+            $id = (int) $userData['id'];
+
+            if ($ghName !== (string) $userData['name']) {
+                $this->db->update('users', ['name' => $ghName], ['id' => $id]);
+            }
+
+            return new User($id, $githubId, $ghName);
         }
 
         $this->db->insert('users', [
             'githubId' => $githubId,
-            'name' => $name,
+            'name' => $ghName,
         ]);
 
         $id = (int) $this->db->lastInsertId();
 
-        return new User($id, $githubId, $name);
+        return new User($id, $githubId, $ghName);
     }
 
     public function getUserCount(): int

--- a/tests/User/UserRepositoryTest.php
+++ b/tests/User/UserRepositoryTest.php
@@ -21,6 +21,7 @@ class UserRepositoryTest extends TestCase
                 'githubId' => 'abc',
                 'name' => 'joe',
             ]);
+        $db->expects($this->never())->method('update');
 
         $user = $repository->getOrCreate('abc', 'joe');
 
@@ -41,11 +42,38 @@ class UserRepositoryTest extends TestCase
             ->with('users', ['githubId' => 'abc', 'name' => 'joe']);
         $db->method('lastInsertId')
             ->willReturn(123);
+        $db->expects($this->never())->method('update');
 
         $user = $repository->getOrCreate('abc', 'joe');
 
         $this->assertEquals(123, $user->id);
         $this->assertEquals('abc', $user->githubId);
         $this->assertEquals('joe', $user->name);
+    }
+
+    /**
+     * @test
+     */
+    public function should_update_user_name(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $repository = new UserRepository($db);
+        $db->method('fetchAssociative')
+           ->willReturn([
+               'id' => 123,
+               'githubId' => 'abc',
+               'name' => 'joe',
+           ]);
+
+        $db->expects($this->once())
+            ->method('update')
+            ->with('users', ['name' => 'jane'], ['id' => 123])
+            ->willReturn(1);
+
+        $user = $repository->getOrCreate('abc', 'jane');
+
+        $this->assertEquals(123, $user->id);
+        $this->assertEquals('abc', $user->githubId);
+        $this->assertEquals('jane', $user->name);
     }
 }


### PR DESCRIPTION
Currently externals.io displays the github name I used the first time I logged in.
Since then, I changed my github handle, but externals.io still has the outdated one.

This PR fixes that.