### PR TITLE
Update the link to the news archive in home.html.twig

### DIFF
--- a/views/home.html.twig
+++ b/views/home.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
 
     <header class="sm:text-lg text-gray-500 font-light py-4 sm:py-8">
-        <p>Opening PHP's <a class="underline" href="http://news.php.net/php.internals" target="_blank" rel="noreferrer noopener">#internals</a> mailing list to the outside.</p>
+        <p>Opening PHP's <a class="underline" href="https://news-web.php.net/php.internals" target="_blank" rel="noreferrer noopener">#internals</a> mailing list to the outside.</p>
         <noscript>
             Your browser either doesn't support javascript or it is disabled.
             This website does not work without javascript.


### PR DESCRIPTION
The old URL doesn't support TLS, which causes warnings in HTTPS only mode (e.g. in Firefox). It also already redirects to the new URL, so let's just use that one.